### PR TITLE
feat: real usage + straico coin price on /v1/chat/completions

### DIFF
--- a/api_endpoints/claude/chat.py
+++ b/api_endpoints/claude/chat.py
@@ -38,7 +38,7 @@ async def message_completion(request: Request):
     else:
         request_msg = json.dumps(messages, indent=True, ensure_ascii=False)
 
-    response_text, thinking_text = await prompt_completion(
+    response_text, thinking_text, _ = await prompt_completion(
         request_msg, None, model, **settings
     )
     if not streaming:

--- a/api_endpoints/lm_studio/chat.py
+++ b/api_endpoints/lm_studio/chat.py
@@ -172,14 +172,14 @@ Example:
     if isinstance(msg, list):
         images, msg = extract_images_from_messages(msg)
         if images is None or len(images) == 0:
-            response, thinking_text = await prompt_completion(
+            response, thinking_text, usage = await prompt_completion(
                 json.dumps(msg, indent=True, ensure_ascii=False),
                 model=model,
                 api_key=api_key,
                 **settings,
             )
         else:
-            response, thinking_text = await prompt_completion(
+            response, thinking_text, usage = await prompt_completion(
                 json.dumps(msg, indent=True, ensure_ascii=False),
                 images=images,
                 model=model,
@@ -187,7 +187,7 @@ Example:
                 **settings,
             )
     else:
-        response, thinking_text = await prompt_completion(
+        response, thinking_text, usage = await prompt_completion(
             json.dumps(msg, indent=True, ensure_ascii=False),
             model=model,
             api_key=api_key,
@@ -364,7 +364,7 @@ Example:
             streamed_response(original_response, model), media_type="text/event-stream"
         )
 
-    return JSONResponse(content=basic_response(original_response, model))
+    return JSONResponse(content=basic_response(original_response, model, usage=usage))
 
 
 @app.post("/v1/completions")
@@ -380,7 +380,7 @@ async def completions(request: Request):
     tracing_context.update_current_observation(input=dict(post_json_data))
     msg = post_json_data["prompt"]
     model = post_json_data.get("model") or "openai/gpt-3.5-turbo-0125"
-    response, thinking_text = await prompt_completion(msg, model=model, api_key=api_key)
+    response, thinking_text, _ = await prompt_completion(msg, model=model, api_key=api_key)
     response = fix_escaped_characters(response)
     return StreamingResponse(
         streamed_response(response, model), content_type="text/event-stream"

--- a/api_endpoints/lm_studio/response/basic/completion_response.py
+++ b/api_endpoints/lm_studio/response/basic/completion_response.py
@@ -1,4 +1,6 @@
-def response(response, model):
+def response(response, model, usage=None):
+    if usage is None:
+        usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
     return {
         "id": "chatcmpl-gg711phlqdwixyxif16bm",
         "object": "chat.completion",
@@ -11,9 +13,5 @@ def response(response, model):
                 "finish_reason": "stop",
             }
         ],
-        "usage": {
-            "prompt_tokens": 426,
-            "completion_tokens": 65,
-            "total_tokens": 491,
-        },
+        "usage": usage,
     }

--- a/api_endpoints/ollama/chat.py
+++ b/api_endpoints/ollama/chat.py
@@ -38,7 +38,7 @@ async def ollamagenerate(request: Request):
         settings["max_tokens"] = options.get("max_tokens")
 
     if msg.get("stream") == False:
-        response, thinking_text = await prompt_completion(
+        response, thinking_text, _ = await prompt_completion(
             msg["prompt"], model=model, **settings
         )
         return JSONResponse(
@@ -55,7 +55,7 @@ async def ollamagenerate(request: Request):
                 "eval_duration": 4232710000,
             }
         )
-    response, thinking_text = await prompt_completion(request_msg, model=model)
+    response, thinking_text, _ = await prompt_completion(request_msg, model=model)
     response = fix_escaped_characters(response)
     return StreamingResponse(
         generate_ollama_stream(response, model), media_type="application/x-ndjson"
@@ -154,7 +154,7 @@ You must respond in valid JSON when using a function. Don't wrap the response in
         messages = new_messages
 
     request_msg = json.dumps(messages, indent=True, ensure_ascii=False)
-    response, thinking_text = await prompt_completion(
+    response, thinking_text, _ = await prompt_completion(
         request_msg, images, model, timeout=timeout, **settings
     )
     if not msg.get("think", False):

--- a/backend/straico.py
+++ b/backend/straico.py
@@ -100,6 +100,31 @@ async def get_model_mapping(api_key=None):
     return models
 
 
+def _extract_usage(response):
+    """Map a Straico prompt-completion response to OpenAI-style usage fields.
+
+    Straico returns word counts under ``words`` (v0) or ``overall_words`` (v1).
+    We surface them via ``prompt_tokens`` / ``completion_tokens`` / ``total_tokens``
+    so existing OpenAI-compat clients see real numbers instead of the legacy
+    hardcoded placeholder. NOTE: the underlying unit is words, not tokenizer
+    tokens — this is an approximation Straico's API does not currently improve on.
+    Returns ``None`` if the response shape does not carry usage info.
+    """
+    if not isinstance(response, dict):
+        return None
+    words = response.get("overall_words") or response.get("words")
+    if not isinstance(words, dict):
+        return None
+    try:
+        return {
+            "prompt_tokens": int(words.get("input", 0)),
+            "completion_tokens": int(words.get("output", 0)),
+            "total_tokens": int(words.get("total", 0)),
+        }
+    except (TypeError, ValueError):
+        return None
+
+
 async def agent_promp_completion(agent_id, msg, api_key=None):
     async with aio_straico_client(
         API_KEY=api_key, timeout=TIMEOUT, on_request_failure_callback=on_error
@@ -107,7 +132,7 @@ async def agent_promp_completion(agent_id, msg, api_key=None):
         settings = chat_settings_read(agent_id)
 
         response = await client.agent_prompt_completion(agent_id, msg, **settings)
-        return response["answer"], ""
+        return response["answer"], "", None
 
 
 @observe
@@ -217,14 +242,14 @@ async def prompt_completion(
             response = await client.prompt_completion(model, msg, **settings)
             logger.debug(f"response body: {response}")
             if response is None:
-                return None, None
+                return None, None, None
             model = list(response["completions"].keys())[0]
             message_last = response["completions"][model]["completion"]["choices"][-1][
                 "message"
             ]
             content = message_last.get("content", "")
             reasoning = message_last.get("reasoning", "")
-            return content, reasoning
+            return content, reasoning, _extract_usage(response)
 
     async with aio_straico_client(
         API_KEY=api_key, timeout=timeout, on_request_failure_callback=on_error
@@ -232,11 +257,11 @@ async def prompt_completion(
         response = await client.prompt_completion(model, msg, **settings)
         logger.debug(f"response body: {response}")
         if response is None:
-            return None, None
+            return None, None, None
         message_last = response["completion"]["choices"][-1]["message"]
         content = message_last.get("content", "")
         reasoning = message_last.get("reasoning", "")
-        return content, reasoning
+        return content, reasoning, _extract_usage(response)
 
 
 async def list_model(api_key=None):

--- a/backend/straico.py
+++ b/backend/straico.py
@@ -108,6 +108,15 @@ def _extract_usage(response):
     so existing OpenAI-compat clients see real numbers instead of the legacy
     hardcoded placeholder. NOTE: the underlying unit is words, not tokenizer
     tokens — this is an approximation Straico's API does not currently improve on.
+
+    When Straico's response also carries ``price`` (v0) or ``overall_price``
+    (v1), the coin debit is surfaced as a vendor-extension subfield
+    ``usage["straico_coins"]`` with the same ``{input, output, total}`` shape.
+    Coins are Straico's billing currency and the only field that maps 1:1
+    with the user's account ledger (distinct from upstream API USD pricing).
+    Price extraction is independent fail-soft: a missing or malformed
+    ``price`` never invalidates word-count usage.
+
     Returns ``None`` if the response shape does not carry usage info.
     """
     if not isinstance(response, dict):
@@ -116,13 +125,24 @@ def _extract_usage(response):
     if not isinstance(words, dict):
         return None
     try:
-        return {
+        usage = {
             "prompt_tokens": int(words.get("input", 0)),
             "completion_tokens": int(words.get("output", 0)),
             "total_tokens": int(words.get("total", 0)),
         }
     except (TypeError, ValueError):
         return None
+    price = response.get("overall_price") or response.get("price")
+    if isinstance(price, dict):
+        try:
+            usage["straico_coins"] = {
+                "input": float(price.get("input", 0)),
+                "output": float(price.get("output", 0)),
+                "total": float(price.get("total", 0)),
+            }
+        except (TypeError, ValueError):
+            pass
+    return usage
 
 
 async def agent_promp_completion(agent_id, msg, api_key=None):

--- a/backend/test.py
+++ b/backend/test.py
@@ -23,11 +23,12 @@ async def prompt_completion(
     post_request_data = {"model": model, "message": msg}
     logger.debug(f"Request Post Data: {post_request_data}")
 
-    return """
+    content = """
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nec felis eu lacus finibus laoreet non non arcu. Mauris et lorem at ligula aliquam sodales sit amet suscipit justo. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. In lectus libero, commodo quis finibus imperdiet, lobortis vitae ex. Cras commodo elit vel erat lobortis pretium. Nunc sagittis elementum ligula a aliquam. Nunc mollis est sodales enim feugiat dignissim. Nam et commodo orci. Quisque id semper nunc. Duis vel convallis elit. Donec dignissim eros in sapien consectetur sagittis. Donec est tortor, convallis non elit id, viverra luctus est. Nullam elementum, tortor eu mattis accumsan, diam lacus tristique elit, placerat viverra lacus urna in massa.
 
 Nunc ac arcu ex. Proin ultrices ultricies semper. Ut id mauris eget tortor tincidunt scelerisque. Sed eget urna at ipsum interdum dapibus ut non ipsum. Nam luctus, arcu posuere iaculis volutpat, est erat finibus ligula, eget iaculis diam leo elementum nisl. Integer congue nec turpis euismod consequat. Duis at sem vitae dolor ornare tristique. Duis dapibus nisi massa, sit amet tristique tortor tempus sit amet. Nunc ac mollis tortor. Cras at elit enim. Sed egestas eget ipsum cursus molestie. Aliquam et finibus nisi, at viverra mi. Sed mattis non magna a semper.
 """
+    return content, "", None
 
 
 async def list_agents(**kwargs):

--- a/test/test_extract_usage.py
+++ b/test/test_extract_usage.py
@@ -1,0 +1,95 @@
+"""Unit tests for backend.straico._extract_usage.
+
+Pure dict-in, dict-out tests — no proxy server needed. Run from repo root:
+
+    .venv/bin/python -m unittest test.test_extract_usage
+
+Covers:
+- Word-count extraction (the e01364b behavior — backfills missing coverage)
+- Coin-price extraction (the new behavior in this PR)
+- Independent fail-soft layering between the two
+- Both v0 (`words`/`price`) and v1 (`overall_words`/`overall_price`) shapes
+"""
+import unittest
+
+from backend.straico import _extract_usage
+
+
+class ExtractUsageWordsTests(unittest.TestCase):
+    """Backfill coverage for the words-as-tokens behavior added in e01364b."""
+
+    def test_words_only_returns_token_counts_without_coins(self):
+        resp = {
+            "completion": {"choices": [{"message": {"content": "ok"}}]},
+            "words": {"input": 4, "output": 1, "total": 5},
+        }
+        usage = _extract_usage(resp)
+        self.assertEqual(usage["prompt_tokens"], 4)
+        self.assertEqual(usage["completion_tokens"], 1)
+        self.assertEqual(usage["total_tokens"], 5)
+        self.assertNotIn("straico_coins", usage)
+
+    def test_no_words_and_no_price_returns_none(self):
+        resp = {"completion": {"choices": [{"message": {"content": "ok"}}]}}
+        self.assertIsNone(_extract_usage(resp))
+
+    def test_non_dict_input_returns_none(self):
+        self.assertIsNone(_extract_usage(None))
+        self.assertIsNone(_extract_usage("not a dict"))
+        self.assertIsNone(_extract_usage(42))
+
+
+class ExtractUsageCoinsTests(unittest.TestCase):
+    """New behavior in this PR: surface Straico's coin price under usage."""
+
+    def test_both_words_and_price_surface_together(self):
+        resp = {
+            "completion": {"choices": [{"message": {"content": "ok"}}]},
+            "words": {"input": 4, "output": 1, "total": 5},
+            "price": {"input": 0.16, "output": 0.04, "total": 0.20},
+        }
+        usage = _extract_usage(resp)
+        # Words still extracted as before.
+        self.assertEqual(usage["prompt_tokens"], 4)
+        self.assertEqual(usage["completion_tokens"], 1)
+        self.assertEqual(usage["total_tokens"], 5)
+        # Coin price now surfaced under straico_coins, preserving per-direction split.
+        self.assertIn("straico_coins", usage)
+        self.assertAlmostEqual(usage["straico_coins"]["input"], 0.16)
+        self.assertAlmostEqual(usage["straico_coins"]["output"], 0.04)
+        self.assertAlmostEqual(usage["straico_coins"]["total"], 0.20)
+
+    def test_malformed_price_leaves_words_intact(self):
+        # Fail-soft: a bad `price` value must NOT invalidate word usage.
+        for bad_price in ["not a dict", 42, None, {"input": "abc", "output": 0, "total": 0}]:
+            with self.subTest(bad_price=bad_price):
+                resp = {
+                    "completion": {"choices": [{"message": {"content": "ok"}}]},
+                    "words": {"input": 4, "output": 1, "total": 5},
+                    "price": bad_price,
+                }
+                usage = _extract_usage(resp)
+                self.assertIsNotNone(usage, f"words must still extract with price={bad_price!r}")
+                self.assertEqual(usage["prompt_tokens"], 4)
+                self.assertNotIn(
+                    "straico_coins",
+                    usage,
+                    f"malformed price must not produce straico_coins (price={bad_price!r})",
+                )
+
+    def test_v1_overall_shape_surfaces_under_standard_field_names(self):
+        # By symmetry with `words` → `overall_words` in e01364b. Defensive
+        # coverage: scope-agent does not use the image (v1) path but the
+        # tolerance prevents a follow-up if Straico ever shifts the default.
+        resp = {
+            "completions": {"model-x": {"completion": {"choices": [{"message": {"content": "ok"}}]}}},
+            "overall_words": {"input": 4, "output": 1, "total": 5},
+            "overall_price": {"input": 0.16, "output": 0.04, "total": 0.20},
+        }
+        usage = _extract_usage(resp)
+        self.assertEqual(usage["total_tokens"], 5)
+        self.assertAlmostEqual(usage["straico_coins"]["total"], 0.20)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Replace the hardcoded `usage` block on non-streaming
`/v1/chat/completions` with real data from Straico's prompt-completion
response. Two commits:

- **7b37a82** — extract `words` (v0) / `overall_words` (v1) → surface as
  `usage.{prompt_tokens, completion_tokens, total_tokens}`. Word counts
  are an approximation for tokenizer tokens; documented in the helper's
  docstring. Replaces the legacy hardcoded `{426, 65, 491}`.

- **0bbb594** — also extract `price` (v0) / `overall_price` (v1) →
  surface under `usage.straico_coins` as a vendor-extension subfield
  with the same `{input, output, total}` shape. Straico's `price` is
  denominated in coins (the actual billing currency); this is distinct
  from token-rate USD approximations clients might otherwise compute.
  Independent fail-soft: malformed or missing `price` never invalidates
  word-count usage.

Scope: lm_studio non-streaming `/v1/chat/completions` only. Streaming,
tool-calls inline, ollama/claude/agent/embedding paths intentionally
deferred (kept open for follow-ups).

## Why surface `price`

The `price` field is the only number in Straico's response that maps
1:1 with the user's account ledger — confirmed empirically by a
balance-delta probe against `/v0/user` across three model families:

| Model                | Reported `price.total` | Account balance delta | Diff           |
|----------------------|------------------------|-----------------------|----------------|
| amazon/nova-lite-v1  | 0.03                   | 0.030000              | 0.000000000    |
| openai/gpt-5-nano    | 0.02                   | 0.020000              | 0.000000000    |
| claude-haiku-4-5-5   | 0.16                   | 0.160000              | 0.000000000    |

Float-exact match (not "within tolerance"). Token-rate USD
approximations don't have this property because (a) Straico returns
word counts, not tokenizer tokens, and (b) Straico's per-model coin
rate is a subscription pricing decision distinct from upstream API
list prices. Clients that want real cost tracking need the real
field.

Surfacing it under `usage.straico_coins` (vendor extension subfield)
keeps the OpenAI-compat response shape standard — clients that don't
recognise it ignore it, clients that do can do meaningful cost
tracking. Precedent for `usage` extensions exists in the ecosystem
(Anthropic's `cache_creation_input_tokens`, OpenAI's
`prompt_tokens_details`).

## Test plan

- [x] Unit tests pass: `PYTHONPATH=. python test/test_extract_usage.py -v`
      → 6/6 OK (covers both v0 and v1 shapes, fail-soft on malformed
      input, None on no-usage response)
- [x] Live v0 probe (single-model text, three model families):
      raw `price.total` == extracted `straico_coins.total`, float-exact
- [x] Live v1 probe (multi-model list, triggers
      `/v1/prompt/completion`): raw `overall_price.total` == extracted
      `straico_coins.total`, float-exact (`{overall_price,
      overall_words, completions}` top-level shape)
- [x] Ledger verification (`/v0/user` balance-delta): reported coins
      == account debit, exact match across 3 models
- [x] HTTP layer: `curl POST /v1/chat/completions` returns populated
      `usage.straico_coins`
- [x] Backward compat: response shape unchanged when `price` is absent
      (purely additive subfield; case covered by test (b)
      `test_words_only_returns_token_counts_without_coins`)